### PR TITLE
Add filename to attachments

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,7 +23,8 @@ var plugin = function(options) {
           cid: randomCid,
           content: base64,
           encoding: 'base64',
-          contentDisposition: 'inline'
+          contentDisposition: 'inline',
+          filename: randomCid
         };
         return randomCid;
       });


### PR DESCRIPTION
Using this plugin with [https://github.com/sendgrid/nodemailer-sendgrid-transport](url) provides error beacuse filename doesn't exists in attachments array.